### PR TITLE
调整单图片页面中的图片位置

### DIFF
--- a/BUPTthesisbachelor.sty
+++ b/BUPTthesisbachelor.sty
@@ -245,6 +245,11 @@ pdfborder=001, linkcolor=black, citecolor=black, urlcolor=black]{hyperref}
 \usepackage{caption}
 \usepackage[position=t,singlelinecheck=off]{subfig}
 
+%使单独成页的图片置顶
+\makeatletter
+\setlength{\@fptop}{0pt}
+\makeatother
+
 % \renewcommand\thesubfigure{\Alph{subfigure}}
 
 \renewcommand{\captionfont}{\ftcaptionfont}


### PR DESCRIPTION
如果一张图片位于章节末尾，最后一页位置不够，以至于单独占用一页，修改后让图片在单独的页面中置顶，而非原先的位于页面垂直剧中的位置

上图为原来效果，下图为修改后效果。虽然这块还是没有明确规定，但是一般来说应该从顶部开始吧？目前未见对其他样式有影响
![原来效果](https://user-images.githubusercontent.com/36398891/120221974-da084480-c271-11eb-9809-0eacb0a8c74c.png)

![修改后](https://user-images.githubusercontent.com/36398891/120222241-353a3700-c272-11eb-8a5d-50ab0d1f9d70.png)

