### PR TITLE
feat: support longtable

### DIFF
--- a/BUPTthesisbachelor.sty
+++ b/BUPTthesisbachelor.sty
@@ -289,6 +289,22 @@ pdfborder=001, linkcolor=black, citecolor=black, urlcolor=black]{hyperref}  % �
     \label{#2}}{%
 \end{table}}%
 
+% longtable tweaking
+% New longtable environment
+% Usage: \begin{buptlongtable}{alignment}{caption}{label}
+%            <normal longtable>
+%        \end{buptlongtable}
+\usepackage{longtable}
+\newenvironment{buptlongtable}[3]{
+    \renewcommand{\arraystretch}{1.38}%
+    \setlength{\abovecaptionskip}{0pt}%
+    \setlength{\belowcaptionskip}{10pt}%
+    \begin{longtable}{#1}
+        \caption{#2}
+        \label{#3} \\
+    }{
+\end{longtable}}
+
 % equation tweaking
 \usepackage{amssymb}
 \usepackage{bm} % 加粗使用


### PR DESCRIPTION
添加了对长表格的支持，效果如下：

<p align="center">
<image src="https://github.com/BYRIO/BUPTBachelorThesis/assets/67569413/628750fb-0e31-4599-9370-39855cc3b5d3" width="60%"></image>
</p>

示例代码如下：

```
\begin{buptlongtable}{|c|c|}{这是一个跨页长表}{longtable-label}
    % 首页表头
    \hline
    \textbf{列1} & \textbf{列2}         \\ \hline
    \endfirsthead

    % 非首页表头
    \hline
    \textbf{列1} & \textbf{列2}         \\ \hline
    \endhead

    % 非末页表尾
    \multicolumn{2}{|r|}{续下页}         \\ \hline
    \endfoot

    % 末页表尾
    \endlastfoot

    % 表格内容
    内容1        & 内容2                 \\ \hline
    内容3        & 内容4                 \\ \hline
    内容5        & 内容6                 \\ \hline
    内容7        & 内容8                 \\ \hline
\end{buptlongtable}
```

以下是几个使用 buptlongtable 的注意事项：
- buptlongtable 需要三个参数，分别为 `列对齐标识符`，`表名`，`标签名`
- 需要定义两个表头（一般来讲不会有差异，复制一下就好）
- 非末页表尾中 `multicolumn` 的 **第一个参数** 应根据实际情况填写表格列宽，此示例中为 2
- 不包含普通表格的 `\begin{tabular} \end{tabular}` 部分
- 有时候表格的显示并不正常（表头宽度没有适应表内容），此时再进行一次 XeLaTeX 编译就好